### PR TITLE
chore(go): Update Go to 1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/fosrl/badger
 
-go 1.23.1
+go 1.24.7


### PR DESCRIPTION
This pull request makes a minor update to the Go version specified in the `go.mod` file, upgrading it from 1.23.1 to 1.24.7.