### PR TITLE
enhance: strip user session information before forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,20 +70,6 @@ trustip:
 customIPHeader: "X-Forwarded-For"
 ```
 
-### Configuration Options Reference
-
-| Option                        | Type     | Required\* | Default | Description                                                                         |
-| ----------------------------- | -------- | ---------- | ------- | ----------------------------------------------------------------------------------- |
-| `disableForwardAuth`          | bool     | No         | `false` | Disable forward auth; only IP handling is performed                                 |
-| `apiBaseUrl`                  | string   | Yes\*      | -       | Base URL of the Pangolin API                                                        |
-| `userSessionCookieName`       | string   | Yes\*      | -       | Cookie name for user sessions                                                       |
-| `resourceSessionRequestParam` | string   | Yes\*      | -       | Query parameter name for resource session requests                                  |
-| `trustip`                     | []string | No         | `[]`    | Array of trusted IP ranges in CIDR format                                           |
-| `disableDefaultCFIPs`         | bool     | No         | `false` | Disable default Cloudflare IP ranges                                                |
-| `customIPHeader`              | string   | No         | `""`    | Custom header name to extract IP from (only used if request is from trusted source) |
-
-\* Required only when `disableForwardAuth` is `false` (default)
-
 ## Updating Cloudflare IPs
 
 To update the Cloudflare IP ranges, run:

--- a/main.go
+++ b/main.go
@@ -17,7 +17,9 @@ type Config struct {
 	APIBaseUrl                  string   `json:"apiBaseUrl,omitempty"`
 	UserSessionCookieName       string   `json:"userSessionCookieName,omitempty"`
 	ResourceSessionRequestParam string   `json:"resourceSessionRequestParam,omitempty"`
-	AccessTokenQueryParam       string   `json:"accessTokenQueryParam,omitempty"` // Deprecated: use ResourceSessionRequestParam
+	AccessTokenQueryParam       string   `json:"accessTokenQueryParam,omitempty"`
+	AccessTokenIDHeader         string   `json:"accessTokenIdHeader,omitempty"`
+	AccessTokenHeader           string   `json:"accessTokenHeader,omitempty"`
 	DisableForwardAuth          bool     `json:"disableForwardAuth,omitempty"`
 	TrustIP                     []string `json:"trustip,omitempty"`
 	DisableDefaultCFIPs         bool     `json:"disableDefaultCFIPs,omitempty"`
@@ -39,6 +41,8 @@ type Badger struct {
 	userSessionCookieName       string
 	resourceSessionRequestParam string
 	accessTokenQueryParam       string
+	accessTokenIDHeader         string
+	accessTokenHeader           string
 	disableForwardAuth          bool
 	trustIP                     []*net.IPNet
 	customIPHeader              string
@@ -98,6 +102,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		userSessionCookieName:       config.UserSessionCookieName,
 		resourceSessionRequestParam: config.ResourceSessionRequestParam,
 		accessTokenQueryParam:       config.AccessTokenQueryParam,
+		accessTokenIDHeader:         config.AccessTokenIDHeader,
+		accessTokenHeader:           config.AccessTokenHeader,
 		disableForwardAuth:          config.DisableForwardAuth,
 		customIPHeader:              config.CustomIPHeader,
 	}
@@ -317,8 +323,7 @@ func (p *Badger) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		p.stripSessionCookies(req)
 		p.stripSessionParam(req)
-		req.Header.Del("P-Access-Token-Id")
-		req.Header.Del("P-Access-Token")
+		p.stripAccessTokenHeaders(req)
 
 		fmt.Println("Badger: Valid session")
 		p.next.ServeHTTP(rw, req)
@@ -436,6 +441,15 @@ func (p *Badger) stripSessionParam(req *http.Request) {
 	if modified {
 		req.URL.RawQuery = query.Encode()
 		req.RequestURI = req.URL.RequestURI()
+	}
+}
+
+func (p *Badger) stripAccessTokenHeaders(req *http.Request) {
+	if p.accessTokenIDHeader != "" {
+		req.Header.Del(p.accessTokenIDHeader)
+	}
+	if p.accessTokenHeader != "" {
+		req.Header.Del(p.accessTokenHeader)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -312,6 +312,9 @@ func (p *Badger) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			req.Header.Add("Remote-Role", *result.Data.Role)
 		}
 
+		p.stripSessionCookies(req)
+		p.stripSessionParam(req)
+
 		fmt.Println("Badger: Valid session")
 		p.next.ServeHTTP(rw, req)
 		return
@@ -412,6 +415,44 @@ func (p *Badger) getRealIP(req *http.Request) string {
 		return req.RemoteAddr
 	}
 	return ip
+}
+
+func (p *Badger) stripSessionParam(req *http.Request) {
+	query := req.URL.Query()
+	if query.Has(p.resourceSessionRequestParam) {
+		query.Del(p.resourceSessionRequestParam)
+		req.URL.RawQuery = query.Encode()
+	}
+}
+
+// stripSessionCookies removes session cookies from the request before forwarding to the backend.
+// We parse the Cookie header as a string rather than using req.Cookies() + re-encoding so we
+// preserve the exact header format; the Cookie request header only carries name=value pairs
+// (domain/path are Set-Cookie response attributes and are not sent in requests per RFC 6265).
+func (p *Badger) stripSessionCookies(req *http.Request) {
+	cookieHeader := req.Header.Get("Cookie")
+	if cookieHeader == "" {
+		return
+	}
+
+	var remaining []string
+	for part := range strings.SplitSeq(cookieHeader, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		parts := strings.SplitN(part, "=", 2)
+		name := strings.TrimSpace(parts[0])
+		if !strings.HasPrefix(name, p.userSessionCookieName) {
+			remaining = append(remaining, part)
+		}
+	}
+
+	if len(remaining) > 0 {
+		req.Header.Set("Cookie", strings.Join(remaining, "; "))
+	} else {
+		req.Header.Del("Cookie")
+	}
 }
 
 func (p *Badger) isTrustedIP(remoteAddr string) bool {

--- a/main.go
+++ b/main.go
@@ -440,54 +440,35 @@ func (p *Badger) stripSessionParam(req *http.Request) {
 }
 
 // stripSessionCookies removes session cookies from the request before forwarding to the backend.
-// Cookie request headers only contain name=value pairs (Set-Cookie attributes like Path/Domain
-// are response-only), so we filter parsed request cookies and rebuild the Cookie header.
+// It processes raw Cookie header pairs so non-target cookies are preserved as-is.
 func (p *Badger) stripSessionCookies(req *http.Request) {
 	cookieHeaders := req.Header.Values("Cookie")
 	if len(cookieHeaders) == 0 {
 		return
 	}
 
-	var remaining []*http.Cookie
+	var remainingPairs []string
 	for _, headerValue := range cookieHeaders {
-		parsedCookies, err := http.ParseCookie(headerValue)
-		if err != nil {
-			// Best-effort fallback for malformed Cookie headers.
-			for _, part := range strings.Split(headerValue, ";") {
-				part = strings.TrimSpace(part)
-				if part == "" {
-					continue
-				}
-				name, value, hasValue := strings.Cut(part, "=")
-				name = strings.TrimSpace(name)
-				if strings.HasPrefix(name, p.userSessionCookieName) {
-					continue
-				}
-				if hasValue {
-					remaining = append(remaining, &http.Cookie{
-						Name:  name,
-						Value: strings.TrimSpace(value),
-					})
-				}
+		for _, part := range strings.Split(headerValue, ";") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
 			}
-			continue
-		}
-
-		for _, cookie := range parsedCookies {
-			if !strings.HasPrefix(cookie.Name, p.userSessionCookieName) {
-				remaining = append(remaining, cookie)
+			name, _, _ := strings.Cut(part, "=")
+			name = strings.TrimSpace(name)
+			if !strings.HasPrefix(name, p.userSessionCookieName) {
+				remainingPairs = append(remainingPairs, part)
 			}
 		}
 	}
 
-	req.Header.Del("Cookie")
-	if len(remaining) == 0 {
+	if len(remainingPairs) == 0 {
+		req.Header.Del("Cookie")
 		return
 	}
 
-	for _, cookie := range remaining {
-		req.AddCookie(cookie)
-	}
+	// Keep a single canonical Cookie header while preserving surviving name=value pairs.
+	req.Header.Set("Cookie", strings.Join(remainingPairs, "; "))
 }
 
 func (p *Badger) isTrustedIP(remoteAddr string) bool {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ type Config struct {
 	APIBaseUrl                  string   `json:"apiBaseUrl,omitempty"`
 	UserSessionCookieName       string   `json:"userSessionCookieName,omitempty"`
 	ResourceSessionRequestParam string   `json:"resourceSessionRequestParam,omitempty"`
+	AccessTokenQueryParam       string   `json:"accessTokenQueryParam,omitempty"` // Deprecated: use ResourceSessionRequestParam
 	DisableForwardAuth          bool     `json:"disableForwardAuth,omitempty"`
 	TrustIP                     []string `json:"trustip,omitempty"`
 	DisableDefaultCFIPs         bool     `json:"disableDefaultCFIPs,omitempty"`
@@ -37,6 +38,7 @@ type Badger struct {
 	apiBaseUrl                  string
 	userSessionCookieName       string
 	resourceSessionRequestParam string
+	accessTokenQueryParam       string
 	disableForwardAuth          bool
 	trustIP                     []*net.IPNet
 	customIPHeader              string
@@ -95,6 +97,7 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		apiBaseUrl:                  config.APIBaseUrl,
 		userSessionCookieName:       config.UserSessionCookieName,
 		resourceSessionRequestParam: config.ResourceSessionRequestParam,
+		accessTokenQueryParam:       config.AccessTokenQueryParam,
 		disableForwardAuth:          config.DisableForwardAuth,
 		customIPHeader:              config.CustomIPHeader,
 	}
@@ -314,6 +317,8 @@ func (p *Badger) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 		p.stripSessionCookies(req)
 		p.stripSessionParam(req)
+		req.Header.Del("P-Access-Token-Id")
+		req.Header.Del("P-Access-Token")
 
 		fmt.Println("Badger: Valid session")
 		p.next.ServeHTTP(rw, req)
@@ -419,39 +424,69 @@ func (p *Badger) getRealIP(req *http.Request) string {
 
 func (p *Badger) stripSessionParam(req *http.Request) {
 	query := req.URL.Query()
+	modified := false
 	if query.Has(p.resourceSessionRequestParam) {
 		query.Del(p.resourceSessionRequestParam)
+		modified = true
+	}
+	if p.accessTokenQueryParam != "" && query.Has(p.accessTokenQueryParam) {
+		query.Del(p.accessTokenQueryParam)
+		modified = true
+	}
+	if modified {
 		req.URL.RawQuery = query.Encode()
+		req.RequestURI = req.URL.RequestURI()
 	}
 }
 
 // stripSessionCookies removes session cookies from the request before forwarding to the backend.
-// We parse the Cookie header as a string rather than using req.Cookies() + re-encoding so we
-// preserve the exact header format; the Cookie request header only carries name=value pairs
-// (domain/path are Set-Cookie response attributes and are not sent in requests per RFC 6265).
+// Cookie request headers only contain name=value pairs (Set-Cookie attributes like Path/Domain
+// are response-only), so we filter parsed request cookies and rebuild the Cookie header.
 func (p *Badger) stripSessionCookies(req *http.Request) {
-	cookieHeader := req.Header.Get("Cookie")
-	if cookieHeader == "" {
+	cookieHeaders := req.Header.Values("Cookie")
+	if len(cookieHeaders) == 0 {
 		return
 	}
 
-	var remaining []string
-	for part := range strings.SplitSeq(cookieHeader, ";") {
-		part = strings.TrimSpace(part)
-		if part == "" {
+	var remaining []*http.Cookie
+	for _, headerValue := range cookieHeaders {
+		parsedCookies, err := http.ParseCookie(headerValue)
+		if err != nil {
+			// Best-effort fallback for malformed Cookie headers.
+			for _, part := range strings.Split(headerValue, ";") {
+				part = strings.TrimSpace(part)
+				if part == "" {
+					continue
+				}
+				name, value, hasValue := strings.Cut(part, "=")
+				name = strings.TrimSpace(name)
+				if strings.HasPrefix(name, p.userSessionCookieName) {
+					continue
+				}
+				if hasValue {
+					remaining = append(remaining, &http.Cookie{
+						Name:  name,
+						Value: strings.TrimSpace(value),
+					})
+				}
+			}
 			continue
 		}
-		parts := strings.SplitN(part, "=", 2)
-		name := strings.TrimSpace(parts[0])
-		if !strings.HasPrefix(name, p.userSessionCookieName) {
-			remaining = append(remaining, part)
+
+		for _, cookie := range parsedCookies {
+			if !strings.HasPrefix(cookie.Name, p.userSessionCookieName) {
+				remaining = append(remaining, cookie)
+			}
 		}
 	}
 
-	if len(remaining) > 0 {
-		req.Header.Set("Cookie", strings.Join(remaining, "; "))
-	} else {
-		req.Header.Del("Cookie")
+	req.Header.Del("Cookie")
+	if len(remaining) == 0 {
+		return
+	}
+
+	for _, cookie := range remaining {
+		req.AddCookie(cookie)
 	}
 }
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

This PR introduces upstream request sanitization so Badger can consume session/auth data for validation while preventing those sensitive values from being forwarded to backend services.

### Why

Badger should validate session material but not forward that sensitive session/auth context to downstream apps.

This change ensures:

1. Least-privilege forwarding:
Downstream receive identity context, not raw session secrets.

2. Reduced leakage risk:
Session tokens are removed from URL query, headers, and cookies before proxying (and logs/observability systems downstream are less likely to capture secrets).

4. Consistent sanitization:
Stripping is applied in one place for all supported transport paths (query params, headers, cookies).

5. Traefik plugin compatibility:
Implementation avoids APIs unavailable in Yaegi, preventing plugin load failures while keeping sanitization behavior intact.

### What changed

  1. Strip session cookies:

  - Removes only cookies matching userSessionCookieName*
  - Preserves all other cookies untouched
  - Handles multiple Cookie headers
  - Uses Yaegi-compatible parsing logic (no net/http.ParseCookie)

  2. Strip session query params:

  - Removes resourceSessionRequestParam
  - Removes configured access-token query param (when set)

  3. Strip token headers:

  - Removes P-Access-Token-Id
  - Removes P-Access-Token

  4. Keep forwarded identity headers:

  - Continues to pass Remote-User, Remote-Email, Remote-Name, Remote-Role when session is valid

  ### Behavior notes

  - Request cookies only carry name=value; Set-Cookie attributes (Path/Domain/SameSite/etc.) are response-side and are not modified here.
  - This logic avoids mutating unrelated cookies beyond normal header re-join formatting.

## How to test?

Personally I setup a whoami container behind pangolin SSO and used an invite link, use a preauthenticated browser to access the resource, what was echoed to the page was all sensitive information being removed before forwarded to backend service but headers for user auth like remote-user are preserved.